### PR TITLE
First draft of an API for Kotlin.

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -1,0 +1,31 @@
+group 'jvm-redux'
+version '1.0-SNAPSHOT'
+
+buildscript {
+    ext.kotlin_version = '1.0.3'
+
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+apply plugin: 'kotlin'
+
+repositories {
+    mavenCentral()
+    maven { url "http://repository.jetbrains.com/all" }
+}
+
+configurations {
+    ktlint
+    testOutput
+}
+
+dependencies {
+    ktlint 'com.github.shyiko:ktlint:0.1.2'
+
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+}

--- a/kotlin/src/main/kotlin/redux/api/Dispatcher.kt
+++ b/kotlin/src/main/kotlin/redux/api/Dispatcher.kt
@@ -1,0 +1,48 @@
+package redux.api
+
+/*
+ * Copyright (C) 2016 Michael Pardo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A dispatcher is an interface that accepts an action or an async action; it then may or may not dispatch one or more
+ * actions to the store.
+ *
+ * @see <a href="http://redux.js.org/docs/Glossary.html#dispatching-function">http://redux.js.org/docs/Glossary.html#dispatching-function</a>
+ */
+interface Dispatcher {
+
+    /**
+     * Dispatches an action. This is the only way to trigger a state change.
+     *
+     * ## Example
+     * ```
+     * sealed class Action {
+     *     class AddTodo(val todo: String) : Action()
+     * }
+     *
+     * val store = Store.create(todos, listOf("Use Redux"))
+     *
+     * store.dispatch(AddTodo("Read the docs"))
+     * store.dispatch(AddTodo("Read about the middleware"))
+     * ```
+     *
+     * @see <a href="http://redux.js.org/docs/api/Store.html#dispatch">http://redux.js.org/docs/api/Store.html#dispatch</a>
+     *
+     * @param[action] A plain object describing the change that makes sense for your application
+     * @return The dispatched action
+     */
+    fun dispatch(action: Any): Any
+}

--- a/kotlin/src/main/kotlin/redux/api/Middleware.kt
+++ b/kotlin/src/main/kotlin/redux/api/Middleware.kt
@@ -1,0 +1,59 @@
+package redux.api
+
+/*
+ * Copyright (C) 2016 Michael Pardo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides a third-party extension point between dispatching an action, and the moment it reaches the reducer.
+ *
+ * @see <a href="http://redux.js.org/docs/advanced/Middleware.html">http://redux.js.org/docs/advanced/Middleware.html</a>
+ */
+interface Middleware<S : Any> {
+
+    /**
+     * Apply middleware behavior to the dispatched action.
+     *
+     * ## Example
+     *
+     * ```kotlin
+     * Middleware { store: Store&lt;S&gt;, action: Any, next: Dispatcher ->
+     *     println("Previous state: $store")
+     *     val result = next.dispatch(action)
+     *     println("New state: $store")
+     *     result
+     * }
+     * ```
+     *
+     * @param[store] The previous state
+     * @param[action] A plain object describing the change that makes sense for your application
+     * @param[next] The next dispatcher to call
+     * @return The dispatched action
+     */
+    fun dispatch(store: Store<S>, action: Any, next: Dispatcher): Any
+
+    companion object {
+        /**
+         * Creates a new [Middleware] instance using the provided function as the [dispatch()] implementation.
+         *
+         * @param[f] A higher-order function equivalent to the [dispatch()] function
+         * @return A new middleware instance
+         */
+        operator fun <S : Any> invoke(f: (Store<S>, Any, Dispatcher) -> Any) = object : Middleware<S> {
+            override fun dispatch(store: Store<S>, action: Any, next: Dispatcher) = f(store, action, next)
+        }
+
+    }
+}

--- a/kotlin/src/main/kotlin/redux/api/Reducer.kt
+++ b/kotlin/src/main/kotlin/redux/api/Reducer.kt
@@ -1,0 +1,58 @@
+package redux.api
+
+/*
+ * Copyright (C) 2016 Michael Pardo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A reducer accepts an accumulation and a value and returns a new accumulation. They are used to reduce a collection of
+ * values down to a single value.
+ *
+ * @see <a href="http://redux.js.org/docs/basics/Reducers.html">http://redux.js.org/docs/basics/Reducers.html</a>
+ */
+interface Reducer<S : Any> {
+
+    /**
+     * A pure function which returns a new state given the previous state and an action.
+     *
+     * Things you should never do inside a reducer:
+     * * Mutate its arguments;
+     * * Perform side effects like API calls and routing transitions;
+     * * Call non-pure functions, e.g. Date.now() or Math.random().
+     *
+     * Given the same arguments, it should calculate the next state and return it. No surprises. No side effects. No API
+     * calls. No mutations. Just a calculation.
+     *
+     * @see <a href="http://redux.js.org/docs/basics/Reducers.html">http://redux.js.org/docs/basics/Reducers.html</a>
+     *
+     * @param[state] The previous state
+     * @param[action] The dispatched action
+     * @return The new state
+     */
+    fun reduce(state: S, action: Any): S
+
+    companion object {
+
+        /**
+         * Creates a new [Reducer] instance using the provided function as the [reduce()] implementation.
+         *
+         * @param[f] A higher-order function equivalent to the [reduce()] function
+         * @return A new reducer instance
+         */
+        operator fun <S : Any> invoke(f: (S, Any) -> S) = object : Reducer<S> {
+            override fun reduce(state: S, action: Any) = f(state, action)
+        }
+    }
+}

--- a/kotlin/src/main/kotlin/redux/api/Store.kt
+++ b/kotlin/src/main/kotlin/redux/api/Store.kt
@@ -1,0 +1,159 @@
+package redux.api
+
+/*
+ * Copyright (C) 2016 Michael Pardo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Coordinates actions and [Reducers][Reducer]. Store has the following responsibilities:
+ * * Holds application state
+ * * Allows access to state via [getState()]
+ * * Allows state to be updated via [dispatch()]
+ * * Registers listeners via [subscribe()]
+ * * Handles unregistering of listeners via the [Subscriber] returned by [subscribe()]
+ *
+ * @see <a href="http://redux.js.org/docs/basics/Store.html">http://redux.js.org/docs/basics/Store.html</a>
+ */
+interface Store<S : Any> : Dispatcher {
+
+    /**
+     * Returns the current state tree of your application. It is equal to the last value returned by the store’s
+     * reducer.
+     *
+     * @see <a href="http://redux.js.org/docs/api/Store.html#getState">http://redux.js.org/docs/api/Store.html#getState</a>
+     *
+     * @return the current state
+     */
+    fun getState(): S
+
+    /**
+     * Adds a change listener. It will be called any time an action is dispatched, and some part of the state tree may
+     * potentially have changed. You may then call [getState()] to read the current state tree inside the callback.
+     *
+     * @see <a href="http://redux.js.org/docs/api/Store.html#subscribe">http://redux.js.org/docs/api/Store.html#subscribe</a>
+     *
+     * @param[subscriber] The subscriber
+     * @return A subscription
+     */
+    fun subscribe(subscriber: Subscriber): Subscription
+
+    /**
+     * Adds a change listener. It will be called any time an action is dispatched, and some part of the state tree may
+     * potentially have changed. You may then call [getState()] to read the current state tree inside the callback.
+     *
+     * @see <a href="http://redux.js.org/docs/api/Store.html#subscribe">http://redux.js.org/docs/api/Store.html#subscribe</a>
+     *
+     * @param[subscriber] The subscriber function
+     * @return A subscription
+     */
+    fun subscribe(subscriber: () -> Unit) = subscribe(Subscriber(subscriber))
+
+    /**
+     * Replaces the reducer currently used by the store to calculate the state.
+     *
+     * @see <a href="http://redux.js.org/docs/api/Store.html#replaceReducer">http://redux.js.org/docs/api/Store.html#replaceReducer</a>
+     *
+     * @param[reducer] The reducer
+     */
+    fun replaceReducer(reducer: Reducer<S>)
+
+    /**
+     * An interface that creates a Redux store.
+     *
+     * @see <a href="http://redux.js.org/docs/Glossary.html#store-creator">http://redux.js.org/docs/Glossary.html#store-creator</a>
+     */
+    interface Creator {
+
+        /**
+         *
+         */
+        fun <S : Any> create(reducer: Reducer<S>, initialState: S, enhancer: Enhancer? = null): Store<S>
+    }
+
+    /**
+     * An interface that composes a store creator to return a new, enhanced store creator.
+     *
+     * @see <a href="http://redux.js.org/docs/Glossary.html#store-enhancer">http://redux.js.org/docs/Glossary.html#store-enhancer</a>
+     */
+    interface Enhancer {
+
+        /**
+         *
+         */
+        fun enhance(next: Creator): Creator
+
+        companion object {
+            operator fun invoke(f: (Creator) -> Creator) = object : Enhancer {
+                override fun enhance(next: Creator): Creator = f(next)
+            }
+        }
+    }
+
+    /**
+     * A listener which will be called any time an action is dispatched, and some part of the state tree may potentially
+     * have changed. You may then call [getState()] to read the current state tree inside the listener.
+     *
+     * @see <a href="http://redux.js.org/docs/api/Store.html#subscribe">http://redux.js.org/docs/api/Store.html#subscribe</a>
+     */
+    interface Subscriber {
+
+        /**
+         * Called any time an action is dispatched.
+         */
+        fun onStateChanged()
+
+        companion object {
+
+            /**
+             * Creates a new [Subscriber] instance using the provided function as the [onStateChanged()] implementation.
+             *
+             * @param[f] A higher-order function equivalent to the [onStateChanged()] function
+             * @return A new subscriber instance
+             */
+            operator fun invoke(f: () -> Unit) = object : Subscriber {
+                override fun onStateChanged() = f()
+            }
+
+        }
+
+    }
+
+    /**
+     * A reference to the [Subscriber] to allow for unsubscription.
+     */
+    interface Subscription {
+
+        /**
+         * Unsubscribe the [Subscriber] from the [Store].
+         */
+        fun unsubscribe()
+
+        companion object {
+            operator fun invoke(f: () -> Unit) = object : Subscription {
+                override fun unsubscribe() = f()
+            }
+
+        }
+    }
+
+    companion object {
+
+        /**
+         * When a store is created, an "INIT" action is dispatched so that every reducer returns their initial state.
+         * This effectively populates the initial state tree.
+         */
+        object INIT {}
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+include 'kotlin'
+


### PR DESCRIPTION
# Scope

Verbatim port of the Redux API for Kotlin.

The API aims to meet the following criteria : 
- Redux's vanilla API
- Documented 
- Kotlin idiomatic 
- No logic (exemples : combineReducers, store creation)

[Redux-Kotlin's API](https://github.com/pardom/redux-kotlin) by @pardom is really good to that regards (and many others). For that reason, it made no sense to me to redo it, that's why I forked it and change only a few things (I hope you won't mind Michael 🙏 ). The changes are highlighted in the comments.
# Details

I was able to demonstrate this API is compatible with the following store implementations : 
- [Bansa](https://github.com/brianegan/bansa) -> [api's adapter](https://github.com/glung/jvm-redux/tree/master/adapter-bansa)
- [Kedux](https://github.com/AngusMorton/kedux) -> [api's adapter](https://github.com/glung/jvm-redux/tree/master/adapter-kedux)
- [Redux-Kotlin](https://github.com/pardom/redux-kotlin/) -> [api's adapter](https://github.com/glung/jvm-redux/tree/master/adapter-redux-kotlin)
- [Reduks](https://github.com/beyondeye/Reduks) -> [api's adapter](https://github.com/glung/jvm-redux/tree/master/adapter-Reduks)
- [Redux-Java](https://github.com/glung/redux-java) -> [api's adapter](https://github.com/glung/jvm-redux/tree/master/adapter-redux-java)

Here is an example of a middleware implemented on the top of this API : [jvm-redux-devtools-instrument](https://github.com/glung/jvm-redux-devtools-instrument)
