### PR TITLE
Make the INIT action a reference to a typed singleton.

### DIFF
--- a/api/src/main/java/redux/api/Store.java
+++ b/api/src/main/java/redux/api/Store.java
@@ -17,7 +17,7 @@ public interface Store<S> extends Dispatcher {
 	/**
 	 * Initialization action reference.
 	 */
-	Init INIT = Init.INSTANCE
+	Init INIT = Init.INSTANCE;
 
 	/**
 	 * Returns the current state tree of your application. It is equal to the last value returned by the store’s
@@ -62,6 +62,7 @@ public interface Store<S> extends Dispatcher {
 		 * @return The store
 		 */
 		Store<S> create(Reducer<S> reducer, S initialState);
+
 	}
 
 	/**
@@ -78,6 +79,7 @@ public interface Store<S> extends Dispatcher {
 		 * @return The composed store creator
 		 */
 		Creator<S> enhance(Creator<S> next);
+
 	}
 
 	/**
@@ -92,6 +94,7 @@ public interface Store<S> extends Dispatcher {
 		 * Called any time an action is dispatched.
 		 */
 		void onStateChanged();
+
 	}
 
 	/**
@@ -102,7 +105,6 @@ public interface Store<S> extends Dispatcher {
 		Subscription EMPTY = new Subscription() {
 			@Override
 			public void unsubscribe() {
-
 			}
 		};
 
@@ -110,6 +112,7 @@ public interface Store<S> extends Dispatcher {
 		 * Unsubscribe the {@link Subscriber} from the {@link Store}.
 		 */
 		void unsubscribe();
+
 	}
 
 	/**
@@ -119,7 +122,7 @@ public interface Store<S> extends Dispatcher {
 
 		private static final Init INSTANCE = new Init();
 
-		private Init()
+		private Init() {}
 
 	}
 

--- a/api/src/main/java/redux/api/Store.java
+++ b/api/src/main/java/redux/api/Store.java
@@ -14,9 +14,12 @@ package redux.api;
  */
 public interface Store<S> extends Dispatcher {
 
-	Object INIT = new Object();
+	/**
+	 * Initialization action reference.
+	 */
+	Init INIT = Init.INSTANCE
 
-    /**
+	/**
 	 * Returns the current state tree of your application. It is equal to the last value returned by the store’s
 	 * reducer.
 	 *
@@ -59,7 +62,6 @@ public interface Store<S> extends Dispatcher {
 		 * @return The store
 		 */
 		Store<S> create(Reducer<S> reducer, S initialState);
-
 	}
 
 	/**
@@ -76,7 +78,6 @@ public interface Store<S> extends Dispatcher {
 		 * @return The composed store creator
 		 */
 		Creator<S> enhance(Creator<S> next);
-
 	}
 
 	/**
@@ -91,7 +92,6 @@ public interface Store<S> extends Dispatcher {
 		 * Called any time an action is dispatched.
 		 */
 		void onStateChanged();
-
 	}
 
 	/**
@@ -106,10 +106,20 @@ public interface Store<S> extends Dispatcher {
 			}
 		};
 
-        /**
+		/**
 		 * Unsubscribe the {@link Subscriber} from the {@link Store}.
 		 */
 		void unsubscribe();
+	}
+
+	/**
+	 * Initialization action.
+	 */
+	public final class Init {
+
+		private static final Init INSTANCE = new Init();
+
+		private Init()
 
 	}
 


### PR DESCRIPTION
The current implementation of `Store.INIT` does not allow for type checking/filtering. For instance, on an Rx stream of actions:

```kotlin
val initStream = actions.ofType(Store.INIT::class.java)
                .map { Action.GetTeams() }
```

This currently does not work correctly because `Store.INIT` is of type `Object`.